### PR TITLE
2019.refactor.int.code

### DIFF
--- a/2019/day2_5_7_9_11/src/bin/day11_part1.rs
+++ b/2019/day2_5_7_9_11/src/bin/day11_part1.rs
@@ -1,7 +1,8 @@
-use std::{cell::RefCell, rc::Rc};
-
 use day2_5_7_9_11::{
-    int_code::{com::IntCodeComputer, read_int_code},
+    int_code::{
+        com::{IODevice, IntCodeComputer},
+        read_int_code,
+    },
     paint::{PaintRobot, PaintSimulator},
 };
 
@@ -18,20 +19,24 @@ fn main() {
         }
     };
 
-    let simulator = Rc::new(RefCell::new(PaintSimulator::new(PaintRobot::new())));
+    let io_dev = IODevice::new(PaintSimulator::new(PaintRobot::new()));
     let mut computer = IntCodeComputer::new(true);
-    match computer.execute_with_io(&int_code, simulator.clone(), simulator.clone()) {
-        Ok(res) => println!(
-            "After {} steps, painting program halt, get outputs({:?})",
-            res.step_count(),
-            simulator.borrow().outputs()
-        ),
+    match computer.execute_with_io(&int_code, io_dev.input_device(), io_dev.output_device()) {
+        Ok(res) => io_dev.check(|ps| {
+            println!(
+                "After {} steps, painting program halt, get outputs({:?})",
+                res.step_count(),
+                ps.outputs()
+            )
+        }),
         Err(e) => eprintln!("Failed to run painting program, get error({})", e),
     };
 
-    println!(
-        "In whole painting process, robot has painted {} times and {} blocks",
-        simulator.borrow().robot().paint_count(),
-        simulator.borrow().robot().block_count()
-    );
+    io_dev.check(|ps| {
+        println!(
+            "In whole painting process, robot has painted {} times and {} blocks",
+            ps.robot().paint_count(),
+            ps.robot().block_count()
+        );
+    });
 }

--- a/2019/day2_5_7_9_11/src/bin/day11_part2.rs
+++ b/2019/day2_5_7_9_11/src/bin/day11_part2.rs
@@ -1,7 +1,8 @@
-use std::{cell::RefCell, rc::Rc};
-
 use day2_5_7_9_11::{
-    int_code::{com::IntCodeComputer, read_int_code},
+    int_code::{
+        com::{IODevice, IntCodeComputer},
+        read_int_code,
+    },
     paint::{Color, PaintRobot, PaintSimulator},
 };
 
@@ -20,17 +21,19 @@ fn main() {
 
     let mut robot = PaintRobot::new();
     robot.paint(Color::White);
-    let simulator = Rc::new(RefCell::new(PaintSimulator::new(robot)));
+    let io_dev = IODevice::new(PaintSimulator::new(robot));
     let mut computer = IntCodeComputer::new(true);
-    match computer.execute_with_io(&int_code, simulator.clone(), simulator.clone()) {
-        Ok(res) => println!(
-            "After {} steps, painting program halt, get outputs({:?})",
-            res.step_count(),
-            simulator.borrow().outputs()
-        ),
+    match computer.execute_with_io(&int_code, io_dev.input_device(), io_dev.output_device()) {
+        Ok(res) => io_dev.check(|ps| {
+            println!(
+                "After {} steps, painting program halt, get outputs({:?})",
+                res.step_count(),
+                ps.outputs()
+            )
+        }),
         Err(e) => eprintln!("Failed to run painting program, get error({})", e),
     };
 
     println!("After painting, robot get image:");
-    println!("{}", &simulator.borrow().robot().image());
+    io_dev.check(|ps| println!("{}", ps.robot().image()));
 }

--- a/2019/day2_5_7_9_11/src/bin/day2_part1.rs
+++ b/2019/day2_5_7_9_11/src/bin/day2_part1.rs
@@ -1,7 +1,5 @@
-use std::{cell::RefCell, rc::Rc};
-
 use day2_5_7_9_11::int_code::{
-    com::{Channel, IntCodeComputer},
+    com::{Channel, InputDevice, IntCodeComputer, OutputDevice},
     read_int_code,
 };
 
@@ -12,9 +10,9 @@ fn main() {
     int_code[1] = 12;
     int_code[2] = 2;
     let mut computer = IntCodeComputer::new(false);
-    let input_chan = Rc::new(RefCell::new(Channel::new(&[])));
-    let output_chan = Rc::new(RefCell::new(Channel::new(&[])));
-    match computer.execute_with_io(&int_code, input_chan, output_chan) {
+    let input_dev = InputDevice::new(Channel::new(&[]));
+    let output_dev = OutputDevice::new(Channel::new(&[]));
+    match computer.execute_with_io(&int_code, input_dev, output_dev) {
         Ok(res) => println!(
             "After {} steps, program halt, code[0] = {}",
             res.step_count(),

--- a/2019/day2_5_7_9_11/src/bin/day2_part2.rs
+++ b/2019/day2_5_7_9_11/src/bin/day2_part2.rs
@@ -1,7 +1,5 @@
-use std::{cell::RefCell, rc::Rc};
-
 use day2_5_7_9_11::int_code::{
-    com::{Channel, IntCodeComputer},
+    com::{Channel, InputDevice, IntCodeComputer, OutputDevice},
     read_int_code,
 };
 
@@ -16,9 +14,9 @@ fn main() {
             let mut int_code_image = int_code.clone();
             int_code_image[1] = code1;
             int_code_image[2] = code2;
-            let input_chan = Rc::new(RefCell::new(Channel::new(&[])));
-            let output_chan = Rc::new(RefCell::new(Channel::new(&[])));
-            match computer.execute_with_io(&int_code_image, input_chan, output_chan) {
+            let input_dev = InputDevice::new(Channel::new(&[]));
+            let output_dev = OutputDevice::new(Channel::new(&[]));
+            match computer.execute_with_io(&int_code_image, input_dev, output_dev) {
                 Ok(res) => println!(
                     "{:>2} | {:>2}: After {} steps, program halts, code[0] = {}",
                     code1,

--- a/2019/day2_5_7_9_11/src/bin/day5_part1.rs
+++ b/2019/day2_5_7_9_11/src/bin/day5_part1.rs
@@ -1,7 +1,5 @@
-use std::{cell::RefCell, rc::Rc};
-
 use day2_5_7_9_11::int_code::{
-    com::{Channel, IntCodeComputer},
+    com::{Channel, InputDevice, IntCodeComputer, OutputDevice},
     read_int_code,
 };
 
@@ -12,14 +10,16 @@ fn main() {
         int_code_file
     ));
     let mut computer = IntCodeComputer::new(false);
-    let input_chan = Rc::new(RefCell::new(Channel::new(&[1])));
-    let output_chan = Rc::new(RefCell::new(Channel::new(&[])));
-    match computer.execute_with_io(&int_code, input_chan, output_chan.clone()) {
-        Ok(res) => println!(
-            "After {} steps, execution finished, Outputs: {:?}",
-            res.step_count(),
-            output_chan.borrow().data()
-        ),
+    let input_dev = InputDevice::new(Channel::new(&[1]));
+    let output_dev = OutputDevice::new(Channel::new(&[]));
+    match computer.execute_with_io(&int_code, input_dev, output_dev.clone()) {
+        Ok(res) => output_dev.check(|c| {
+            println!(
+                "After {} steps, execution finished, Outputs: {:?}",
+                res.step_count(),
+                c.data()
+            );
+        }),
         Err(e) => eprintln!("Failed to execute int code, get error({})", e),
     }
 }

--- a/2019/day2_5_7_9_11/src/bin/day5_part2.rs
+++ b/2019/day2_5_7_9_11/src/bin/day5_part2.rs
@@ -1,7 +1,5 @@
-use std::{cell::RefCell, rc::Rc};
-
 use day2_5_7_9_11::int_code::{
-    com::{Channel, IntCodeComputer},
+    com::{Channel, InputDevice, IntCodeComputer, OutputDevice},
     read_int_code,
 };
 
@@ -12,14 +10,16 @@ fn main() {
         int_code_file
     ));
     let mut computer = IntCodeComputer::new(false);
-    let input_chan = Rc::new(RefCell::new(Channel::new(&[5])));
-    let output_chan = Rc::new(RefCell::new(Channel::new(&[])));
-    match computer.execute_with_io(&int_code, input_chan, output_chan.clone()) {
-        Ok(res) => println!(
-            "After {} steps, execution finished, Outputs: {:?}",
-            res.step_count(),
-            output_chan.borrow().data()
-        ),
+    let input_dev = InputDevice::new(Channel::new(&[5]));
+    let output_dev = OutputDevice::new(Channel::new(&[]));
+    match computer.execute_with_io(&int_code, input_dev, output_dev.clone()) {
+        Ok(res) => output_dev.check(|c| {
+            println!(
+                "After {} steps, execution finished, Outputs: {:?}",
+                res.step_count(),
+                c.data()
+            )
+        }),
         Err(e) => eprintln!("Failed to execute int code, get error({})", e),
     }
 }

--- a/2019/day2_5_7_9_11/src/bin/day9_part1.rs
+++ b/2019/day2_5_7_9_11/src/bin/day9_part1.rs
@@ -1,7 +1,5 @@
-use std::{cell::RefCell, rc::Rc};
-
 use day2_5_7_9_11::int_code::{
-    com::{Channel, IntCodeComputer},
+    com::{Channel, InputDevice, IntCodeComputer, OutputDevice},
     read_int_code,
 };
 
@@ -19,14 +17,16 @@ fn main() {
     };
 
     let mut computer = IntCodeComputer::new(true);
-    let input_chan = Rc::new(RefCell::new(Channel::new(&[1])));
-    let output_chan = Rc::new(RefCell::new(Channel::new(&[])));
-    match computer.execute_with_io(&int_code, input_chan, output_chan.clone()) {
-        Ok(res) => println!(
-            "Boost program in test mode takes {} steps to finish, get outputs({:?})",
-            res.step_count(),
-            output_chan.borrow().data()
-        ),
+    let input_dev = InputDevice::new(Channel::new(&[1]));
+    let output_dev = OutputDevice::new(Channel::new(&[]));
+    match computer.execute_with_io(&int_code, input_dev, output_dev.clone()) {
+        Ok(res) => output_dev.check(|c| {
+            println!(
+                "Boost program in test mode takes {} steps to finish, get outputs({:?})",
+                res.step_count(),
+                c.data()
+            )
+        }),
         Err(e) => eprintln!(
             "Failed to execute Boost program in test mode, get error({})",
             e

--- a/2019/day2_5_7_9_11/src/bin/day9_part2.rs
+++ b/2019/day2_5_7_9_11/src/bin/day9_part2.rs
@@ -1,7 +1,5 @@
-use std::{cell::RefCell, rc::Rc};
-
 use day2_5_7_9_11::int_code::{
-    com::{Channel, IntCodeComputer},
+    com::{Channel, InputDevice, IntCodeComputer, OutputDevice},
     read_int_code,
 };
 
@@ -19,14 +17,16 @@ fn main() {
     };
 
     let mut computer = IntCodeComputer::new(true);
-    let input_chan = Rc::new(RefCell::new(Channel::new(&[2])));
-    let output_chan = Rc::new(RefCell::new(Channel::new(&[])));
-    match computer.execute_with_io(&int_code, input_chan, output_chan.clone()) {
-        Ok(res) => println!(
-            "Boost program in sensor boost mode takes {} steps to finish, get outputs({:?})",
-            res.step_count(),
-            output_chan.borrow().data()
-        ),
+    let input_dev = InputDevice::new(Channel::new(&[2]));
+    let output_dev = OutputDevice::new(Channel::new(&[]));
+    match computer.execute_with_io(&int_code, input_dev, output_dev.clone()) {
+        Ok(res) => output_dev.check(|c| {
+            println!(
+                "Boost program in sensor boost mode takes {} steps to finish, get outputs({:?})",
+                res.step_count(),
+                c.data()
+            )
+        }),
         Err(e) => eprintln!(
             "Failed to execute Boost program in sensor boost, get error({})",
             e


### PR DESCRIPTION
Refactor implementation about references of input/output, use generics and encapsulation to hide the use of Rc and RefCell and make it easier to change in the future.