### PR TITLE
Optimize the part 2 of day18

### DIFF
--- a/2024/day18/src/bin/part2.rs
+++ b/2024/day18/src/bin/part2.rs
@@ -14,19 +14,23 @@ fn main() -> Result<()> {
     let mut map = Map::new_square(args.map_size);
     let start_pos = Position::new(0, 0);
     let end_pos = Position::new(args.map_size - 1, args.map_size - 1);
-    let mut first_break_corrupt_pos = None;
-    for corrupt_pos in &corr_positions {
-        map.corrupt(&[corrupt_pos.clone()]);
-        if map.min_steps_n(&start_pos, &end_pos).is_none() {
-            first_break_corrupt_pos = Some(corrupt_pos.clone());
-            break;
+    let mut clear_ind = 0;
+    let mut blocked_ind = corr_positions.len();
+    while clear_ind < blocked_ind {
+        let center_ind = (clear_ind + blocked_ind) / 2;
+        map.reset();
+        map.corrupt(&corr_positions[..(center_ind + 1)]);
+        if map.min_steps_n(&start_pos, &end_pos).is_some() {
+            clear_ind = center_ind + 1;
+        } else {
+            blocked_ind = center_ind;
         }
     }
 
-    if let Some(pos) = first_break_corrupt_pos {
+    if let Some(first_blocking_corr_pos) = corr_positions.get(blocked_ind) {
         println!(
             "The first corrupted position that makes no path from {} to {} exists is {}.",
-            start_pos, end_pos, pos
+            start_pos, end_pos, first_blocking_corr_pos
         );
     } else {
         eprintln!(

--- a/2024/day18/src/lib.rs
+++ b/2024/day18/src/lib.rs
@@ -112,7 +112,7 @@ enum Tile {
     Corrupted,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Map {
     tiles: Vec<Tile>,
     row_n: usize,
@@ -137,6 +137,12 @@ impl Map {
             if let Some(tile_mut) = self.tile_mut(pos) {
                 *tile_mut = Tile::Corrupted;
             }
+        }
+    }
+
+    pub fn reset(&mut self) {
+        for tile in &mut self.tiles {
+            *tile = Tile::Fine;
         }
     }
 


### PR DESCRIPTION
Instead of using linear search, the binary search can significantly reduce the test count(total running time).